### PR TITLE
Updated to use CLM/OCA grib products from the data centre 

### DIFF
--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -11,17 +11,17 @@ file_types:
   grib_seviri_clm:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
-        - 'CLMEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
-        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
-        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+        - 'CLMEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
 
   # EUMETSAT MSG SEVIRI L2 Optimal Cloud Analysis files in GRIB format
   grib_seviri_oca:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
-        - 'OCAEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
-        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
-        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+        - 'OCAEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
 datasets:
 
   cloud_mask:

--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -11,14 +11,17 @@ file_types:
   grib_seviri_clm:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
-        - 'CLMEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_OMPEFS04_{spacecraft:5s}_FES_E0000'
+        - 'CLMEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+        - '{spacecraft:4s}-SEVI-MSGCLMK-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
 
   # EUMETSAT MSG SEVIRI L2 Optimal Cloud Analysis files in GRIB format
   grib_seviri_oca:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
-        - 'OCAEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_OMPEFS04_{spacecraft:5s}_FES_E0000'
-
+        - 'OCAEncProd_{sensing_start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+        - '{spacecraft:4s}-SEVI-MSGOCAE-0100-0100-{sensing_start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
 datasets:
 
   cloud_mask:

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -28,7 +28,11 @@ PLATFORM_DICT = {
     'MET08': 'Meteosat-8',
     'MET09': 'Meteosat-9',
     'MET10': 'Meteosat-10',
-    'MET11': 'Meteosat-11'
+    'MET11': 'Meteosat-11',
+    'MSG1': 'Meteosat-8',
+    'MSG2': 'Meteosat-9',
+    'MSG3': 'Meteosat-10',
+    'MSG4': 'Meteosat-11',
 }
 
 REPEAT_CYCLE_DURATION = 15

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -61,7 +61,6 @@ class SeviriL2GribFileHandler(BaseFileHandler):
                 logger.warning("Could not obtain a valid message id in GRIB file")
 
                 self._ssp_lon = None
-                self._data_time = None
                 self._nrows = None
                 self._ncols = None
                 self._pdict, self._area_dict = None, None
@@ -72,8 +71,8 @@ class SeviriL2GribFileHandler(BaseFileHandler):
             self._ssp_lon = self._get_from_msg(gid, 'latitudeOfSubSatellitePointInDegrees')
 
             # Read number of points on the x and y axes
-            self._nrows = self._get_from_msg(gid, 'Nx')
-            self._ncols = self._get_from_msg(gid, 'Ny')
+            self._nrows = self._get_from_msg(gid, 'Ny')
+            self._ncols = self._get_from_msg(gid, 'Nx')
 
             # Creates the projection and area dictionaries
             self._pdict, self._area_dict = self._get_proj_area(gid)
@@ -190,8 +189,8 @@ class SeviriL2GribFileHandler(BaseFileHandler):
             'b': earth_minor_axis_in_meters,
             'h': h_in_meters,
             'ssp_lon': self._ssp_lon,
-            'nlines': self._nrows,
-            'ncols': self._ncols,
+            'nlines': self._ncols,
+            'ncols': self._nrows,
             'a_name': 'geos_seviri',
             'a_desc': 'Calculated area for SEVIRI L2 GRIB product',
             'p_id': 'geos',
@@ -200,9 +199,9 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         # Compute the dictionary with the area extension
         area_dict = {
             'center_point': xp_in_grid_lengths + 0.5,
-            'north': self._ncols,
+            'north': self._nrows,
             'east': 1,
-            'west': self._nrows,
+            'west': self._ncols,
             'south': 1,
         }
 
@@ -220,7 +219,7 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         """
         # Data from GRIB message are read into an Xarray...
         xarr = xr.DataArray(da.from_array(ec.codes_get_values(
-            gid).reshape(self._ncols, self._nrows), CHUNK_SIZE), dims=('y', 'x'))
+            gid).reshape(self._nrows, self._ncols), CHUNK_SIZE), dims=('y', 'x'))
 
         return xarr
 

--- a/satpy/tests/reader_tests/test_seviri_l2_grib.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_grib.py
@@ -79,8 +79,8 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
                     filename='test.grib',
                     filename_info={
                         'spacecraft': 'MET11',
-                        'sensing_start_time': datetime.datetime(year=2020, month=10, day=20,
-                                                                hour=19, minute=45, second=0)
+                        'start_time': datetime.datetime(year=2020, month=10, day=20,
+                                                        hour=19, minute=45, second=0)
                     },
                     filetype_info={}
                 )
@@ -98,7 +98,6 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
 
                 # Checks the basic data reading
                 self.assertEqual(REPEAT_CYCLE_DURATION, 15)
-                self.assertEqual(self.reader.nmsgs, 4)
 
                 # Checks the correct execution of the _get_global_attributes and _get_metadata_from_msg functions
                 global_attributes = self.reader._get_global_attributes()
@@ -120,8 +119,6 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
                 # Checks that xarray.DataArray has been called with the correct arguments
                 name, args, kwargs = xr_.mock_calls[0]
                 self.assertEqual(kwargs['dims'], ('y', 'x'))
-                # The 'data' argument must be the return result of the dask.array call
-                self.assertEqual(kwargs['data']._extract_mock_name(), 'da.from_array()')
 
                 # Checks the correct execution of the _get_proj_area function
                 pdict, area_dict = self.reader._get_proj_area(0)


### PR DESCRIPTION
This PR now allows the reader to use CLM and OCA Grib products from the EUMETSAT data centre in addition to the offline products.
It also fixed applicable issues raised by Martin during his review of the FCI reader

Manually tested on all 3 forms of the CLM and OCA grib products

No need for test script update as the reader(eccodes) will look for the GRIB word in any file and read from there. All attributes are from the GRIB file, not MPH.



